### PR TITLE
Create docker_run.sh

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,0 +1,4 @@
+docker run -v /host/directory:/opt/conjur/backup --name conjur -d --restart=always \
+  --security-opt seccomp:unconfined \
+  -p "443:443" -p "636:636" -p "5432:5432" -p "5433:5433" \
+  registry.tld/conjur-appliance:4.9.18.0


### PR DESCRIPTION
Use to launch the Conjur appliance and mount a local volume into `/opt/conjur/backup` in the container.