### PR TITLE
Fix docker-compose image target

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   conjur:
-    image: registry.tld/conjur-appliance:5.0-stable
+    image: registry2.itci.conjur.net/conjur-appliance:5.0-stable
     ports:
       - "443:443"
     security_opt:


### PR DESCRIPTION
Since the appliance is only in the private registry, there's no
need to generalize the registry TLD.